### PR TITLE
オーストラリア対応  &  Windows10対応

### DIFF
--- a/gcp_block_country.py
+++ b/gcp_block_country.py
@@ -69,8 +69,7 @@ def create_rule(name, addresses, *, dry_run):
         print('Run:', ' '.join(args))
         return
 
-    return subprocess.run(args, check=True)
-
+    return subprocess.run(args, check=True,shell=True)
 
 def get_addresses(country_code):
     """アドレス一覧を取得する"""

--- a/gcp_block_country.py
+++ b/gcp_block_country.py
@@ -9,6 +9,7 @@ CHUNK_SIZE = 256
 COUNTRIES = {
     'cn': 'block-china-',
     'ru': 'block-russia-',
+    'au': 'block-australia-',
 }
 
 


### PR DESCRIPTION
・オーストラリア対応
GCP Compute Engine では、中国とオーストラリアの通信費が有料のためブロックしたい。
https://cloud.google.com/free/

・Windows10対応
windows10環境でdry-runは問題がなかったが、実際に走らせるとgcloudが見つからないエラーが出たため。